### PR TITLE
Correct use of discriminators to OAS 3.0

### DIFF
--- a/types/AreaMeasureType.json
+++ b/types/AreaMeasureType.json
@@ -2,12 +2,9 @@
     "description": "Specifies an area, including units (default is m2). Express 1 hectare as 10,000 m2.",
     
     "type": "object",
-    "discriminator": {
-        "propertyName": "areaMeasureType"
-    },
 
     "properties": {
-        "area": {
+        "measurement": {
             "type": "number",
             "description": "The area of the spatial resource (in the specified units)."
         },

--- a/types/ClassificationType.json
+++ b/types/ClassificationType.json
@@ -2,9 +2,6 @@
     "description": "Defines a hierarchical classification within a defined classification scheme. Used for soils, slope, land use capability, etc.",
     
     "type": "object",
-    "discriminator": {
-        "propertyName": "classificationType"
-    },
 
     "properties": {
         "scheme": {

--- a/types/CropType.json
+++ b/types/CropType.json
@@ -2,9 +2,6 @@
     "description": "Defines a managed crop, or a species in a mixed sward (or even potentially a weed species).",
     
     "type": "object",
-    "discriminator": {
-        "propertyName": "cropType"
-    },
 
     "properties": {
         "name": {

--- a/types/IdentifierType.json
+++ b/types/IdentifierType.json
@@ -2,9 +2,6 @@
     "description": "A compound identifier that can uniquely identify resources or other items.",
     
     "type": "object",
-    "discriminator": {
-        "propertyName": "identifierType"
-    },
 
     "required": [
         "scheme",

--- a/types/LandUseActivityType.json
+++ b/types/LandUseActivityType.json
@@ -2,9 +2,6 @@
     "description": "Describes a land use activity that might be applied to a Site or Plot.",
     
     "type": "object",
-    "discriminator": {
-        "propertyName": "landUseActivityType"
-    },
 
     "required": [
         "id"

--- a/types/RelationType.json
+++ b/types/RelationType.json
@@ -3,10 +3,6 @@
 
   "type": "object",
 
-  "discriminator": {
-    "propertyName": "relationType"
-  },
-
   "properties": {
     "relationship": {
       "type": "string",

--- a/types/ResourceType.json
+++ b/types/ResourceType.json
@@ -4,8 +4,14 @@
     "type": "object",
   
     "discriminator": {
-      "propertyName": "baseResource"
+      "propertyName": "resourceType"
     },
+
+    "required": [
+      "resourceType", 
+      "id",
+      "meta"
+    ],
   
     "properties": {
       "id": {
@@ -33,6 +39,10 @@
       "name": {
         "type": "string",
         "description": "A user-readable name for the resource."
+      },
+      "resourceType": {
+        "type": "string",
+        "description": "This MUST be populated with the name of the concrete type to support inheritance and deserialisation."
       },
       "@self": {
         "type": "string",


### PR DESCRIPTION
This changes corrects use of discriminators in line with OAS 3.0.
Resolves #32 
See that details for notes, including for openapi-generator usage with Java and C#.
