### PR TITLE
Define Places (point features)

### DIFF
--- a/resources/PlaceResource.json
+++ b/resources/PlaceResource.json
@@ -1,0 +1,53 @@
+{
+  "description": "Represents a place or point feature",
+  "allOf": [
+    {
+      "$ref": "../types/SpatialResourceType.json"
+    },
+    {
+      "type": "object",
+
+      "properties": {
+        "class": {
+          "description": "Defines the topographic class or 'type of thing'. Uses a scheme and ID - e.g. { 'nz.govt.topo', 'helipad_pnt' }.",
+          "$ref": "../types/IdentifierType.json"
+        },
+
+        "address" : {
+          "description": "The physical address of the item.",
+          "anyOf": [
+            { "type": "string" },
+            { "$ref": "../types/PostalAddress.json" }
+          ]
+        },
+        "globalLocationNumber": {
+          "description": "The Global Location Number (GLN, sometimes also referred to as International Location Number or ILN) of the respective organization, person, or place. The GLN is a 13-digit number used to identify parties and physical locations.",
+          "type": "string"
+        },
+        "isAccessibleForFree": {
+          "description": "A flag to signal that the item, event, or place is accessible for free.",
+          "type": "boolean"
+        },
+        "isicV4": {
+          "description": "The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place.",
+          "type": "string"
+        },
+        "logo": {
+          "description": "An associated logo.",
+          "type": "string"
+        },
+        "map": {
+          "description": "A URL to a map of the place.",
+          "oneOf": [
+            { "type": "string", "format": "uri" },
+            { "type": "array", "items": { "type": "string", "format": "uri" } }
+          ]
+        },
+        "publicAccess": {
+          "description": "A flag to signal that the Place is open to public visitors.  If this property is omitted there is no assumed default boolean value",
+          "type": "boolean"
+        }        
+      }
+    }
+  ]
+}

--- a/types/PostalAddress.json
+++ b/types/PostalAddress.json
@@ -1,0 +1,32 @@
+{
+  "title": "PostalAddress",
+  "description": "The mailing address (from schema.org).",
+  "type": "object",
+
+  "properties": {
+    "addressCountry": {
+      "description": "The country. For example, USA. You can also provide the two-letter ISO 3166-1 alpha-2 country code.",
+      "type": "string"
+    },
+    "addressLocality": {
+      "description": "The locality in which the street address is, and which is in the region. For example, Mountain View.",
+      "type": "string"
+    },
+    "addressRegion": {
+      "description": "The region in which the locality is, and which is in the country. For example, California or another appropriate first-level Administrative division",
+      "type": "string"
+    },
+    "postOfficeBoxNumber": {
+      "description": "The post office box number for PO box addresses.",
+      "type": "string"
+    },
+    "postalCode": {
+      "description": "The postal code. For example, 94043.",
+      "type": "string"
+    },
+    "streetAddress": {
+      "description": "The street address. For example, 1600 Amphitheatre Pkwy.",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
Defines a Places resource type with a number of properties, most importantly:
- `address` (postal or street address)
- `class` - the topographic class to which this belongs, using a scheme (e.g., `nz.govt.topo`) and ID (e.g., `helipad_pnt`).

Resolves #12 

Note: You will not be able to merge this successfully until `SpatialResourceType` is defined (#28).