### PR TITLE
Define a land cover resource that can be used for biodiversity and biocontrol zones

### DIFF
--- a/enums/DAFORabundance.json
+++ b/enums/DAFORabundance.json
@@ -1,0 +1,14 @@
+{
+    "description": "DAFOR ecology species abundance scale, from Peter Morris 1995 (https://doi.org/10.4324/9780203892909)",
+  
+    "type": "string",
+  
+    "enum": [
+      "Dominant", 
+      "Abundant",
+      "Frequent",
+      "Occasional", 
+      "Rare",
+      "NotObserved"
+    ]
+  }

--- a/resources/LandCoverResource.json
+++ b/resources/LandCoverResource.json
@@ -1,5 +1,5 @@
 {
-    "description": "Representation of an land management unit (sometimes called block, though this name can be used elsewhere). A polygon feature in GeoJSON.",
+    "description": "Representation of a land cover of some sort, from hedges and helipads to forests and swamps.",
     "allOf": [
       {
         "$ref": "../types/LandUseResourceType.json"

--- a/resources/LandCoverResource.json
+++ b/resources/LandCoverResource.json
@@ -1,0 +1,32 @@
+{
+    "description": "Representation of an land management unit (sometimes called block, though this name can be used elsewhere). A polygon feature in GeoJSON.",
+    "allOf": [
+      {
+        "$ref": "../types/LandUseResourceType.json"
+      },
+      {
+        "type": "object",
+
+        "properties": {
+          "landCoverClass": {
+            "description": "Defines the class of land cover object (e.g., scheme: 'nz.lcdb.5.classes', primary: 'helipad_pnt').",
+            "$ref" : "../types/ClassificationType.json"
+          },
+
+          "speciesPresent": {
+            "description": "An array of species that have been observed at this feature (this is a summary, not individual observations).",
+
+            "type": "array",
+            "items": {
+              "$ref": "../types/SpeciesPresenceType.json"
+            }
+          },
+
+          "eligibility": {
+            "description": "Classification under a compliance or funding programme.",
+            "$ref": "../types/ComplianceEligibilityType.json"
+          }
+        }
+      }
+    ]
+  }

--- a/types/ComplianceEligibilityType.json
+++ b/types/ComplianceEligibilityType.json
@@ -10,8 +10,8 @@
 
             "properties": {
                 "eligible": {
-                    "type": "boolean",
-                    "description": "True if recognised as eligible or compliant."
+                    "type": "string",
+                    "description": "A value defined by the scheme that indicates eligible, partially eligible (of some sort), or ineligible."
                 }
             }
         }

--- a/types/ComplianceEligibilityType.json
+++ b/types/ComplianceEligibilityType.json
@@ -1,0 +1,19 @@
+{
+    "description": "Extends a hierarchical classification within a defined classification scheme for compliance or funding eligibility.",
+    
+    "allOf": [
+        {
+            "$ref": "../types/ClassificationType.json"
+        },
+        {
+            "type": "object",
+
+            "properties": {
+                "eligible": {
+                    "type": "boolean",
+                    "description": "True if recognised as eligible or compliant."
+                }
+            }
+        }
+    ]
+}

--- a/types/SpeciesPresenceType.json
+++ b/types/SpeciesPresenceType.json
@@ -1,0 +1,24 @@
+{
+    "description": "Identifies a species that has been observed to be present at a geographic feature. This is NOT an observation event, but a summary of last known state.",
+    
+    "type": "object",
+
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Common human readable name of the species (e.g., Radiata Pine)"
+        },
+        "taxonomicName": {
+            "type": "string",
+            "description": "Taxonomic (genus/species) name that distinguishes this species (e.g. Pinus radiata)."
+        },
+        "classfication": {
+            "description": "Classification of biodiversity group using a recognised scheme (for instance scheme: 'https://doi.org/10.1002/pan3.10285', primary:'IntroducedWoodyPlants')",
+            "$ref": "../types/ClassificationType.json"
+        },
+        "abundance" : {
+            "description": "DAFOR scale abundance (Peter Morris 1995, https://doi.org/10.4324/9780203892909)",
+            "$ref": "../enums/DAFORabundance.json"
+        }
+    }
+}


### PR DESCRIPTION
LandCoverResource has:
* id, identifiers, name, links, resourceType from `ResourceType`
* totalLength/totalArea from `SpatialResourceType`
* arrays of classifications and activities from `LandUseResourceType`
* `landCoverClass` - a structured categorisation using a scheme that defines the type of land cover (e.g. NZ, AU, or UN land covers)
* `speciesPresent` - species that may be present with relative abundance and ecological group
* `eligibility` - eligibility under some government or other classification

Resolves #22 

**Note: You won't be able to merge this successfully until #28 is merged (depends on this for base classes).**