### PR TITLE
Fix/mass or volume measurement type syntax

### DIFF
--- a/types/HumidityMeasureType.json
+++ b/types/HumidityMeasureType.json
@@ -9,7 +9,7 @@
             "type": "object",
             "required": [],
             "properties": {
-                "unit": {
+                "units": {
                     "$ref": "../enums/uncefactHumidityUnits.json",
                     "nullable": true,
                     "default": "P1",

--- a/types/IrradianceMeasureType.json
+++ b/types/IrradianceMeasureType.json
@@ -9,7 +9,7 @@
             "type": "object",
             "required": [],
             "properties": {
-                "unit": {
+                "units": {
                     "$ref": "../enums/uncefactIrradianceUnits.json",
                     "nullable": true,
                     "default": "D54",

--- a/types/MassOrVolumeMeasurementType.json
+++ b/types/MassOrVolumeMeasurementType.json
@@ -1,30 +1,22 @@
 {
     "description": "Specifies product quantity that may be weight- or volume-based, including units (there is no default).",
-
     "allOf": [
         {
-            "$ref": "../types/MeasurementType.json" 
+            "$ref": "../types/MeasurementType.json"
         },
-        {    
-            "type": "object",
-            "properties": {
-                "anyOf": [
-                    {
-                        "units": {
-                            "$ref": "../enums/uncefactMassUnits.json", 
-                            "nullable": true,
-                            "description": "Defines the unit of measure for weight quantities"
-                        }
-                    },
-                    {
-                        "units": {
-                            "$ref": "../enums/uncefactVolumeUnits.json", 
-                            "nullable": true,
-                            "description": "Defines the unit of measure for volume quantities."
-                        }
-                    }
-                ]
-            }
+        {
+            "anyOf": [
+                {
+                    "$ref": "../enums/uncefactMassUnits.json",
+                    "nullable": true,
+                    "description": "Defines the unit of measure for weight quantities"
+                },
+                {
+                    "$ref": "../enums/uncefactVolumeUnits.json",
+                    "nullable": true,
+                    "description": "Defines the unit of measure for volume quantities."
+                }
+            ]
         }
     ]
 }

--- a/types/MassOrVolumeMeasurementType.json
+++ b/types/MassOrVolumeMeasurementType.json
@@ -3,9 +3,11 @@
     "allOf": [
         {
             "$ref": "../types/MeasurementType.json"
-        },
-        {
-            "anyOf": [
+        }
+    ],
+    "properties":{
+        "units":{
+            "anyOf":[
                 {
                     "$ref": "../enums/uncefactMassUnits.json",
                     "nullable": true,
@@ -18,5 +20,5 @@
                 }
             ]
         }
-    ]
+    }
 }


### PR DESCRIPTION
1. Change unit to units in Humidity and Irradiance measure types to make it consistent with the other Measure Types.
2. Fix Mass or Volume measurement type to properly combine the 2 enums (was causing failures when attempting to use this schema with quicktype to build C# classes from the schema)