### PR TITLE
Add a work-record resource type 

### DIFF
--- a/well-known/known-RelationType.json
+++ b/well-known/known-RelationType.json
@@ -3,5 +3,6 @@
     { "relationship": "Primary Contact", "type": "ContactPoint" },
     { "relationship": "Visitor Reception", "type": "Place" },
     { "relationship": "Fire Alarm Call Point", "type": "Place" },
-    { "relationship": "Holding", "type": "HoldingResource" }
+    { "relationship": "Holding", "type": "HoldingResource" },
+    { "relationship": "WorkRecord", "type": "WorkRecordResource" }
 ]

--- a/well-known/known-ResourceType.json
+++ b/well-known/known-ResourceType.json
@@ -1,5 +1,6 @@
 [
     { "name": "Holding", "type": "HoldingResource" },
     { "name": "Site", "type": "SiteResource" },
-    { "name": "Plot", "type": "PlotResource" }
+    { "name": "Plot", "type": "PlotResource" },
+    { "name": "WorkRecord", "type": "WorkRecordResource" }
 ]


### PR DESCRIPTION
Creating this PR to match the work being done in PureFarming

* Adds a Crop Work Record resource type

Required by the `links > content-type` field in the Resource-Type schema:

https://github.com/Datalinker-Org/Geospatial/blob/dc05222eba59beee7d743f9d31bbfe8819d3ed1c/types/ResourceType.json#L28-L33

https://github.com/Datalinker-Org/Geospatial/blob/dc05222eba59beee7d743f9d31bbfe8819d3ed1c/types/RelationType.json#L11-L14