### PR TITLE
feat: add UN/CEFACT mass or volume units

### DIFF
--- a/enums/uncefactMassOrVolumeUnits.json
+++ b/enums/uncefactMassOrVolumeUnits.json
@@ -1,0 +1,15 @@
+{
+    "description": "Defines the unit of measure for weight or volume quantities",
+    "anyOf":[
+       {
+          "$ref": "https://raw.githubusercontent.com/Pure-Farming/DataLinker-Geospatial/master/enums/uncefactMassUnits.json",
+          "nullable": true,
+          "description": "Defines the unit of measure for weight quantities"
+       },
+       {
+          "$ref": "https://raw.githubusercontent.com/Pure-Farming/DataLinker-Geospatial/master/enums/uncefactVolumeUnits.json",
+          "nullable": true,
+          "description": "Defines the unit of measure for volume quantities."
+       }
+    ]
+}

--- a/types/MassOrVolumeMeasurementType.json
+++ b/types/MassOrVolumeMeasurementType.json
@@ -7,18 +7,7 @@
     ],
     "properties":{
         "units":{
-            "anyOf":[
-                {
-                    "$ref": "../enums/uncefactMassUnits.json",
-                    "nullable": true,
-                    "description": "Defines the unit of measure for weight quantities"
-                },
-                {
-                    "$ref": "../enums/uncefactVolumeUnits.json",
-                    "nullable": true,
-                    "description": "Defines the unit of measure for volume quantities."
-                }
-            ]
+            "$ref": "../enums/uncefactMassOrVolumeUnits.json"
         }
     }
 }


### PR DESCRIPTION
This PR adds a combined enum for the mass and volume units, as used in the `MassOrVolumeMeasurementType`.

This is to better support code generation (generation tools don't particularly like `anyOf` or `oneOf`).