### PR TITLE
Geospatial - fixed error, added schemes, updated schemes in examples

### DIFF
--- a/resources/OperationRecordResource.json
+++ b/resources/OperationRecordResource.json
@@ -47,7 +47,7 @@
             "operation": "Fertiliser Application",
             "operationName": "Urea + Selenium Block 4",
             "observationDate": "2022-11-01T00:00:00.000Z",
-            "resourceType": "OperationRecordResource,
+            "resourceType": "OperationRecordResource",
             "id": "b4683e10-7f91-44ae-8722-214796378a34",
             "meta": {
                 "sourceId": {

--- a/resources/WorkRecordResource.json
+++ b/resources/WorkRecordResource.json
@@ -122,13 +122,13 @@
                     "form": "WaterSolublePowder",
                     "registrations": [
                       {
-                        "scheme": "nz.govt.nzfsa.eatsafe.acvm.register",
+                        "scheme": "nz.govt.acvm.register",
                         "id": "64092"
                       }
                     ],
                     "withdrawals": [
                       {
-                        "scheme": "nz.govt.nzfsa.eatsafe.acvm.whp",
+                        "scheme": "nz.govt.acvm.whp",
                         "hours": 144
                       }
                     ],
@@ -203,7 +203,7 @@
                 "variety": "XYZ 381",
                 "identifiers": [
                   {
-                    "scheme": "nz.co.abcseeds/maize",
+                    "scheme": "nz.co.abcseeds.maize",
                     "id": "XYZ381"
                   }
                 ],
@@ -256,13 +256,13 @@
               ],
               "withdrawals": [
                 {
-                  "scheme": "nz.govt.nzfsa.eatsafe.acvm.whp",
+                  "scheme": "nz.govt.acvm.whp",
                   "hours": 72
                 }
               ],
               "registrations": [
                 {
-                  "scheme": "nz.govt.nzfsa.eatsafe.acvm.register",
+                  "scheme": "nz.govt.acvm.register",
                   "id": "93091"
                 }
               ]

--- a/types/ComponentProductType.json
+++ b/types/ComponentProductType.json
@@ -20,5 +20,46 @@
             "$ref": "../types/MassOrVolumeMeasurementType.json",
             "description": "The quantity of this product which is included in the mix. You should additionally calculate percent if feasible."
         }
-    }
+    },
+    "examples": [
+        {
+            "mixSequence": 2,
+            "percent": 80,
+            "product": {
+                "type": "Fertiliser",
+                "manufacturer": "Fertco Limited",
+                "brand": "Ammonium X + Se",
+                "form": "Granules",
+                "uri": "https://www.fertco.co.nz/products/fertiliser/x-se",
+                "matterState": "Solid",
+                "activeIngredients": [
+                    {
+                        "name": "Urea"
+                    },
+                    {
+                        "name": "Ammonium sulphate"
+                    }
+                ],
+                "analysis": [
+                    {
+                        "name": "N",
+                        "percent": 30.248
+                    },
+                    {
+                        "name": "S",
+                        "percent": 13.731
+                    }
+                ],
+                "crop": {
+                    "name": "Pasture",
+                    "variety": "Ryegrass White Clover",
+                    "establishmentDate": "2020-05-01T00:00:00.000Z"
+                }
+            },
+            "quantity": {
+                "measurement": 1.3,
+                "units": "TNE"
+            }
+        }
+    ]
 }

--- a/well-known/schemes-VetMedicinesAgChemicals.json
+++ b/well-known/schemes-VetMedicinesAgChemicals.json
@@ -1,0 +1,7 @@
+[
+    { "scheme": "nz.govt.acvm.register", "description": "NZ ACVM register for veterinary medicines, agricultural chemicals" },
+    { "scheme": "nz.govt.acvm.whp", "description": "NZ withholding periods for veterinary medicines, agricultural chemicals" },
+    { "scheme": "au.gov.apvma.register", "description": "Australian Pesticides and Veterinary Medicines Authority register" },
+    { "scheme": "au.gov.apvma.whp", "description": "Australia APVMA withholding periods" },
+    { "scheme": "au.gov.apvma.esi", "description": "Australia APVMA export slaughter interval" }
+]


### PR DESCRIPTION
I have fixed an error of a missing quote in OperationRecordResource.

Also added schemes for register and withholding periods of veterinary medicines and agricultural chemicals for Australia and NZ to the "well-known" folder.

Updated schemes in examples to use these schemes.

Added an example to ComponentProductType.