### PR TITLE
Expand OperationRecordResource Operation link

### DIFF
--- a/resources/OperationRecordResource.json
+++ b/resources/OperationRecordResource.json
@@ -12,7 +12,7 @@
     "properties": {
         "operation": {
             "type": "string",
-            "description": "Encoding of the field operation. See well-known/operations-and-methods.md"
+            "description": "Encoding of the field operation. See https://raw.githubusercontent.com/Datalinker-Org/Geospatial/master/well-known/operations-and-methods.md"
         },
         "operationName": {
             "type": "string",


### PR DESCRIPTION
Previously there was a relative link to the allowable operation types:
![image](https://github.com/Datalinker-Org/Geospatial/assets/3358790/3392d11b-380c-4b5c-abc3-5835d8220e7d)

While this is nice for the schema, it does mean that documentation pages generated from the schema aren't very helpful. For example, the Pure Farming developer hub just has this:
![image](https://github.com/Datalinker-Org/Geospatial/assets/3358790/a08f1f81-0e5e-44d5-9de8-26aab0856055)

This PR changes it to the explicit full URL for the `master` branch (**is this the main branch for this repo?**) so that documentation sites have a link to a real file that is able to be found.

For example, in the [Pure Farming Developer Hub](https://developer.purefarming.com/documentation/schema/operationRecordResource.html) it now looks like this:
![image](https://github.com/Datalinker-Org/Geospatial/assets/3358790/b6eec666-8a87-42a7-bbb6-c830876fa63d)

